### PR TITLE
[BUGFIX] Fix reorder for extension keys with 'mask' prefix

### DIFF
--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -169,13 +169,13 @@ class ExportController extends ActionController
     {
         $lowercaseExtensionKey = strtolower(GeneralUtility::underscoredToUpperCamelCase($extensionKey));
         $string = preg_replace(
-            '/(.)mask\\1/',
-            '\\1' . $extensionKey . '\\1',
+            '/(\s+|\'|,|.)(tx_)?mask_/',
+            '\\1\\2' . $lowercaseExtensionKey . '_',
             $string
         );
         $string = preg_replace(
-            '/(\s+|\'|,|.)(tx_)?mask_/',
-            '\\1\\2' . $lowercaseExtensionKey . '_',
+            '/(.)mask\\1/',
+            '\\1' . $extensionKey . '\\1',
             $string
         );
         $string = preg_replace(


### PR DESCRIPTION
Due to commit 43c66fd61fd6bda06387655389dbee41fed3fc4f a reordering of
extension key replacement was introduced which breaks extension keys with 'mask'
prefix. This patch resolves the replacement of both cases.