### PR TITLE
[FEATURE] Allow overwriting root paths

### DIFF
--- a/Classes/Aggregate/ContentRenderingAggregate.php
+++ b/Classes/Aggregate/ContentRenderingAggregate.php
@@ -90,18 +90,16 @@ class ContentRenderingAggregate extends AbstractOverridesAggregate implements Pl
 
         $this->addPlainTextFile(
             $this->typoScriptFilePath . 'constants.ts',
-<<<EOS
-plugin.tx_mask {
-    view {
-        # cat=mask/file; type=string; label= Path to template root (FE)
-		templateRootPath = 
+            <<<EOS
+# cat=mask/file; type=string; label=Path to template root (FE)
+plugin.tx_mask.view.templateRootPath =
 
-		# cat=mask/file; type=string; label= Path to template partials (FE)
-		partialRootPath = 
+# cat=mask/file; type=string; label=Path to template partials (FE)
+plugin.tx_mask.view.partialRootPath =
 
-		# cat=mask/file; type=string; label= Path to template layouts (FE)
-		layoutRootPath = 
-	}
+# cat=mask/file; type=string; label=Path to template layouts (FE)
+plugin.tx_mask.view.layoutRootPath =
+
 EOS
         );
         $this->addPlainTextFile(
@@ -110,7 +108,7 @@ EOS
         );
         $this->appendPhpFile(
             $this->tcaOverridesFilePath . $this->table . '.php',
-<<<EOS
+            <<<EOS
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
     'mask',
     '{$this->typoScriptFilePath}',
@@ -140,7 +138,7 @@ EOS
         $templateName = GeneralUtility::underscoredToUpperCamelCase($key);
         $this->appendPlainTextFile(
             $this->typoScriptFilePath . 'setup.ts',
-<<<EOS
+            <<<EOS
 tt_content.mask_{$key} = FLUIDTEMPLATE
 tt_content.mask_{$key} {
     layoutRootPaths.0 = {$layoutsPath}
@@ -161,7 +159,7 @@ EOS
 
         $this->appendPlainTextFile(
             $this->typoScriptFilePath . 'setup.ts',
-<<<EOS
+            <<<EOS
 }
 
 EOS
@@ -201,8 +199,7 @@ EOS
                             array_keys($GLOBALS['TCA'][$foreignTable]['columns'])
                         );
                         if (!empty($inlineDataProcession)) {
-                            $dataProcessing .=
-<<<EOS
+                            $dataProcessing .= <<<EOS
 dataProcessing.{$index} {
     {$inlineDataProcession}
 }
@@ -226,8 +223,7 @@ EOS;
      */
     protected function addFileProcessorForField($table, $columnName, $index)
     {
-        return
-<<<EOS
+        return <<<EOS
     dataProcessing.{$index} = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
     dataProcessing.{$index} {
         if.isTrue.field = {$columnName}
@@ -261,8 +257,7 @@ EOS;
             $sorting = $GLOBALS['TCA'][$table]['columns'][$columnName]['config']['foreign_sortby'];
         }
 
-        return
-<<<EOS
+        return <<<EOS
     dataProcessing.{$index} = TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor
     dataProcessing.{$index} {
         if.isTrue.field = {$columnName}

--- a/Classes/Aggregate/ContentRenderingAggregate.php
+++ b/Classes/Aggregate/ContentRenderingAggregate.php
@@ -132,8 +132,11 @@ EOS
 tt_content.mask_{$key} = FLUIDTEMPLATE
 tt_content.mask_{$key} {
     layoutRootPaths.0 = {$layoutsPath}
+    layoutRootPaths.10 = {\$plugin.tx_replaceWithExtKeyForRootPaths.view.layoutRootPath}
     partialRootPaths.0 = {$partialPath}
+    partialRootPaths.10 = {\$plugin.tx_replaceWithExtKeyForRootPaths.view.partialRootPath}
     templateRootPaths.0 = {$templatesPath}
+    templateRootPaths.10 = {\$plugin.tx_replaceWithExtKeyForRootPaths.view.templateRootPath}
     templateName = {$templateName}
 
 EOS

--- a/Classes/Aggregate/ContentRenderingAggregate.php
+++ b/Classes/Aggregate/ContentRenderingAggregate.php
@@ -90,7 +90,19 @@ class ContentRenderingAggregate extends AbstractOverridesAggregate implements Pl
 
         $this->addPlainTextFile(
             $this->typoScriptFilePath . 'constants.ts',
-            ''
+<<<EOS
+plugin.tx_mask {
+    view {
+        # cat=mask/file; type=string; label= Path to template root (FE)
+		templateRootPath = 
+
+		# cat=mask/file; type=string; label= Path to template partials (FE)
+		partialRootPath = 
+
+		# cat=mask/file; type=string; label= Path to template layouts (FE)
+		layoutRootPath = 
+	}
+EOS
         );
         $this->addPlainTextFile(
             $this->typoScriptFilePath . 'setup.ts',
@@ -132,11 +144,11 @@ EOS
 tt_content.mask_{$key} = FLUIDTEMPLATE
 tt_content.mask_{$key} {
     layoutRootPaths.0 = {$layoutsPath}
-    layoutRootPaths.10 = {\$plugin.tx_replaceWithExtKeyForRootPaths.view.layoutRootPath}
+    layoutRootPaths.1 = {\$plugin.tx_mask.view.layoutRootPath}
     partialRootPaths.0 = {$partialPath}
-    partialRootPaths.10 = {\$plugin.tx_replaceWithExtKeyForRootPaths.view.partialRootPath}
+    partialRootPaths.1 = {\$plugin.tx_mask.view.partialRootPath}
     templateRootPaths.0 = {$templatesPath}
-    templateRootPaths.10 = {\$plugin.tx_replaceWithExtKeyForRootPaths.view.templateRootPath}
+    templateRootPaths.1 = {\$plugin.tx_mask.view.templateRootPath}
     templateName = {$templateName}
 
 EOS

--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -216,7 +216,7 @@ class ExportController extends ActionController
             'EXT:' . $extensionKey,
             $string
         );
-        $string = str_replace('tx_replaceWithExtKeyForRootPaths', 'tx_'.$lowercaseExtensionKey, $string);
+        $string = str_replace('tx_replaceWithExtKeyForRootPaths', 'tx_' . $lowercaseExtensionKey, $string);
 
         return $string;
     }

--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -216,6 +216,7 @@ class ExportController extends ActionController
             'EXT:' . $extensionKey,
             $string
         );
+        $string = str_replace('tx_replaceWithExtKeyForRootPaths', 'tx_'.$lowercaseExtensionKey, $string);
 
         return $string;
     }

--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -187,7 +187,7 @@ class ExportController extends ActionController
         $lowercaseExtensionKey = strtolower($camelCasedExtensionKey);
 
         $string = preg_replace(
-            '/(\s+|\'|,|.)(tx_)?mask(_|\.|\/)/',
+            '/(\s+|\'|,|.)(tx_)?mask(_|\.)/',
             '\\1\\2' . $lowercaseExtensionKey . '\\3',
             $string
         );
@@ -207,7 +207,7 @@ class ExportController extends ActionController
             $string
         );
         $string = preg_replace(
-            '/([>(])mask([<)])/',
+            '/([>(=])mask([<)\/])/',
             '\\1' . $extensionKey . '\\2',
             $string
         );

--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -187,8 +187,8 @@ class ExportController extends ActionController
         $lowercaseExtensionKey = strtolower($camelCasedExtensionKey);
 
         $string = preg_replace(
-            '/(\s+|\'|,|.)(tx_)?mask/',
-            '\\1\\2' . $lowercaseExtensionKey,
+            '/(\s+|\'|,|.)(tx_)?mask(_|\.|\/)/',
+            '\\1\\2' . $lowercaseExtensionKey . '\\3',
             $string
         );
         $string = preg_replace(

--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -187,8 +187,8 @@ class ExportController extends ActionController
         $lowercaseExtensionKey = strtolower($camelCasedExtensionKey);
 
         $string = preg_replace(
-            '/(\s+|\'|,|.)(tx_)?mask_/',
-            '\\1\\2' . $lowercaseExtensionKey . '_',
+            '/(\s+|\'|,|.)(tx_)?mask/',
+            '\\1\\2' . $lowercaseExtensionKey,
             $string
         );
         $string = preg_replace(
@@ -216,7 +216,6 @@ class ExportController extends ActionController
             'EXT:' . $extensionKey,
             $string
         );
-        $string = str_replace('tx_replaceWithExtKeyForRootPaths', 'tx_' . $lowercaseExtensionKey, $string);
 
         return $string;
     }


### PR DESCRIPTION
By adding the key 10 to layout-, partial- and templateRootPaths for the FLUIDTEMPLATE
it is now possible to outsource the files to another folder e.g. a template provider.
This is a functionality provided by most of the extensions in TER and should also be a
functionality provided by an extension created with EXT:mask_export