### PR TITLE
[BUGFIX] Prevent exception in backend preview

### DIFF
--- a/Classes/Aggregate/BackendPreviewAggregate.php
+++ b/Classes/Aggregate/BackendPreviewAggregate.php
@@ -98,6 +98,7 @@ EOS
             <<<EOS
 namespace MASK\Mask\Hooks;
 
+use TYPO3\CMS\Backend\Form\Exception;
 use TYPO3\CMS\Backend\Form\FormDataCompiler;
 use TYPO3\CMS\Backend\Form\FormDataGroup\TcaDatabaseRecord;
 use TYPO3\CMS\Backend\View\PageLayoutView;
@@ -153,17 +154,27 @@ class PageLayoutViewDrawItem implements PageLayoutViewDrawItemHookInterface
             'tableName' => 'tt_content',
             'vanillaUid' => (int)\$row['uid'],
         ];
-        \$result = \$formDataCompiler->compile(\$formDataCompilerInput);
-        \$processedRow = \$this->getProcessedData(\$result['databaseRow'], \$result['processedTca']['columns']);
+        try {
+            \$result = \$formDataCompiler->compile(\$formDataCompilerInput);
+            \$processedRow = \$this->getProcessedData(\$result['databaseRow'], \$result['processedTca']['columns']);
+    
+            \$view->assignMultiple(
+                [
+                    'row' => \$row,
+                    'processedRow' => \$processedRow,
+                ]
+            );
+    
+            \$itemContent = \$view->render();
+        } catch (Exception \$exception) {
+            \$message = \$GLOBALS['BE_USER']->errorMsg;
+            if (empty(\$message)) {
+                \$message = \$exception->getMessage() . ' ' . \$exception->getCode();
+            }
 
-        \$view->assignMultiple(
-            [
-                'row' => \$row,
-                'processedRow' => \$processedRow,
-            ]
-        );
-
-        \$itemContent = \$view->render();
+            \$itemContent = \$message;
+        }
+        
         \$drawItem = false;
     }
 


### PR DESCRIPTION
If an editor has insufficient user access to inline children information,
the FormEngine will throw an exception. The PageLayoutViewDrawItem has
to catch possible exceptions and return with a visible error information.

Resolves: #72 