### PR TITLE
[TASK] Introduce typo3/cms-composer-installers v4 support

### DIFF
--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=Settings; type=string; label=Composer path repository: If set, this path will be used as export destination relative to the Composer root directory. Mandatory for typo3/cms-composer-installers v4 or higher. E.g. src/extensions
+composerPathRepository =


### PR DESCRIPTION
With the typo3/cms-composer-installers v4 no local extension path does exist anymore because the extensions are installed in the vendor folder. This patch introduces a configurable Composer path repository path which will be taken as export destination. This path is also very useful in any other Composer installation using the installers lower v4.

If the Composer path repository path is not properly configured in a Composer installation a warning will be shown to the user.

The behavior of non Composer installations is not affected by this change.

DISCLAIMER: the FlashMessages weren't properly shown during my tests, also not the existing once. So far I did not dig deeper into that issue.