### PR TITLE
Add export CLI task

### DIFF
--- a/Classes/Command/ExportCommand.php
+++ b/Classes/Command/ExportCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IchHabRecht\MaskExport\Command;
+
+use IchHabRecht\MaskExport\Controller\ExportController;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Core\Bootstrap;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
+use TYPO3\CMS\Extbase\Mvc\Request;
+use TYPO3\CMS\Extensionmanager\Domain\Model\Extension;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2016 Nicole Cordes <typo3@cordes.co>, CPS-IT GmbH
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * This class provides a CLI command for exporting the mask elements
+ */
+class ExportCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setHelp('Export all mask elements')
+            ->addArgument(
+                'vendorName',
+                InputArgument::REQUIRED,
+                'Vendor name for the new extension'
+            )
+            ->addArgument(
+                'extensionName',
+                InputArgument::REQUIRED,
+                'Extension name for the new extension'
+            )
+            ->addArgument(
+                'path',
+                InputArgument::OPTIONAL,
+                'Path for the extension to be written. Defaults to the usual extension path.'
+            );
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        ['path' => $path, 'extensionName' => $extensionName, 'vendorName' => $vendorName] = $input->getArguments();
+        GeneralUtility::setIndpEnv('TYPO3_REQUEST_URL', '');
+        Bootstrap::initializeBackendUser();
+
+        $request = GeneralUtility::makeInstance(Request::class);
+        $request->setControllerName('Export');
+        $request->setControllerActionName('install');
+        $request->setArguments([
+            'vendorName' => $input->getArgument('vendorName'),
+            'extensionName' => $input->getArgument('extensionName'),
+            'elements' => [],
+        ]);
+        if ($path) {
+            $request->setArgument('path', $path . '/');
+        }
+
+        $controller = GeneralUtility::makeInstance(ExportController::class);
+        $elements = $controller->getAvailableElements();
+        $GLOBALS['BE_USER']->uc['mask_export'] = [
+            'vendorName' => $vendorName,
+            'extensionName' => $extensionName,
+            'elements' => implode(',', array_keys($elements)),
+        ];
+        try {
+            $controller->processRequest($request);
+        } catch (StopActionException $e) {
+            // Ignore this Exception because it is for web requests only
+        }
+        $output->writeln(sprintf(
+            'Extension written to %s%s',
+            $path ? realpath($path) . '/' : Extension::returnInstallPaths()['Local'],
+            $input->getArgument('extensionName')
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -178,15 +178,20 @@ class ExportController extends ActionController
      * @param string $vendorName
      * @param string $extensionName
      * @param array $elements
+     * @param string $path
      */
-    public function installAction($vendorName, $extensionName, $elements)
+    public function installAction($vendorName, $extensionName, $elements, $path = null)
     {
         $paths = Extension::returnInstallPaths();
         if (empty($paths['Local']) || !file_exists($paths['Local'])) {
             throw new \RuntimeException('Local extension install path is missing', 1500061028);
         }
 
-        $extensionPath = $paths['Local'] . $extensionName;
+        if (!$path) {
+            $path = $paths['Local'];
+        }
+
+        $extensionPath = $path . $extensionName;
         $files = $this->getFiles($vendorName, $extensionName, $elements);
         $this->writeExtensionFilesToPath($files, $extensionPath);
 
@@ -288,6 +293,14 @@ class ExportController extends ActionController
         }
 
         return $elements;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAvailableElements()
+    {
+        return $this->maskConfiguration['tt_content']['elements'] ?? [];
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,14 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  IchHabRecht\MaskExport\:
+    resource: '../Classes/*'
+
+  IchHabRecht\MaskExport\Command\ExportCommand:
+    tags:
+      - name: console.command
+        command: 'mask:export'
+        description: 'Export all mask elements'

--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ Simply install mask and mask_export with Composer or the Extension Manager.
 
 ## Usage
 
+### Backend
 - use the mask wizard to configure own content elements
 - change to tab "Code Export"
 - if you like change the extension key, the default one is *my_mask_export*
 - either install or download your extension
+
+### CLI
+./vendor/bin/typo3 mask:export MyVendor my_extension_name [save_path]
 
 ## Best practise
 
@@ -57,7 +61,7 @@ You can find some common configuration in the [my_maskexport_sitepackage](https:
 example site package.
 
 Furthermore you can refer to the slides [CCE (Custom Content Elements) - Best Practice ](https://de.slideshare.net/cpsitgmbh/cce-custom-content-elements-best-practice)
-for additional information. 
+for additional information.
 
 ## Community
 


### PR DESCRIPTION
I have created a CLI task for exporting the mask configuration.
In this way, it is possible to create the extension during an automated deployment, which is my intention with this change.

Usage should pretty much be self explanatory when running the task.

Would be nice if this could be merged or if you can give me feedback for improvement.